### PR TITLE
Update setup.py - referenced README instead of README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'rubenesque.curves',
         'rubenesque.signatures',
     ],
-    long_description=read('README'),
+    long_description=read('README.md'),
     requires=[],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
pip install 'git+https://github.com/latchset/python-rubenesque.git'
gives following error:

```
Collecting git+https://github.com/latchset/python-rubenesque.git
  Cloning https://github.com/latchset/python-rubenesque.git to /tmp/pip-29d24jih-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-29d24jih-build/setup.py", line 47, in <module>
        long_description=read('README'),
      File "/tmp/pip-29d24jih-build/setup.py", line 28, in read
        with open(fname) as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-29d24jih-build/README'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-29d24jih-build/

```